### PR TITLE
feat: implement CLI commands (issue #16)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,6 +11,10 @@ spotifyPlaylistBackups fetches Spotify playlists, converts them to CSV, and uplo
 ### Component Diagram
 
 ```
+┌──────────────────┐
+│  CLI (Typer)     │
+└────────┬─────────┘
+         ▼
 ┌────────────────────┐     ┌──────────────────────┐
 │  Config Settings   │────▶│    Backup Service    │
 └────────────────────┘     └──────────┬───────────┘
@@ -67,16 +71,34 @@ spotifyPlaylistBackups fetches Spotify playlists, converts them to CSV, and uplo
 **Key Files**:
 - `src/backup/service.py`
 
+### CLI Entry Point
+
+**Purpose**: Provide the user-facing command interface.
+
+**Responsibilities**:
+- Parse global flags like `--config`, `--verbose`, and `--dry-run`
+- Load settings and configure logging
+- Trigger OAuth flows for Spotify and Dropbox
+- Dispatch backup, sync, list, and status commands
+
 **Key Files**:
-- `src/component_b.py`
+- `src/main.py`
 
 ## Data Flow
 
-1. Load settings via `load_settings()`.
-2. Create `SpotifyClient` and `DropboxClient`.
-3. `BackupService` fetches playlists and tracks.
-4. `CSVExporter` generates per-playlist CSV output.
-5. Dropbox client uploads the CSV into the backup folder.
+1. CLI command resolves settings and logging configuration.
+2. Load settings via `load_settings()`.
+3. Create `SpotifyClient` and `DropboxClient`.
+4. `BackupService` fetches playlists and tracks.
+5. `CSVExporter` generates per-playlist CSV output.
+6. Dropbox client uploads the CSV into the backup folder.
+
+### CLI Workflow
+
+1. CLI parses command-line arguments and options.
+2. `--config` overrides the YAML path via `SPOTIFY_BACKUPS_CONFIG_PATH`.
+3. The CLI constructs clients and `BackupService`.
+4. Commands emit colored status output and handle errors.
 
 ### Sync Workflow
 
@@ -105,6 +127,15 @@ print(result.successful, result.failed)
 
 sync_result = service.sync_all_playlists()
 print(sync_result.playlists_updated, sync_result.total_new_tracks)
+```
+
+### CLI Example
+
+```bash
+spotify-backup auth spotify
+spotify-backup auth dropbox
+spotify-backup backup
+spotify-backup sync
 ```
 
 ## Design Decisions

--- a/src/main.py
+++ b/src/main.py
@@ -31,21 +31,26 @@ CommandFunc = TypeVar("CommandFunc", bound=Callable[..., object])
 
 def typer_callback(func: CommandFunc) -> CommandFunc:
     """Typed wrapper around the Typer callback decorator."""
-    return cast(Callable[[CommandFunc], CommandFunc], app.callback())(func)
+    decorator: object = app.callback()
+    return cast(Callable[[CommandFunc], CommandFunc], decorator)(func)
 
 
 def typer_command(name: Optional[str] = None) -> Callable[[CommandFunc], CommandFunc]:
     """Typed wrapper around the Typer command decorator."""
     if name:
-        return cast(Callable[[CommandFunc], CommandFunc], app.command(name))
-    return cast(Callable[[CommandFunc], CommandFunc], app.command())
+        decorator: object = app.command(name)
+    else:
+        decorator = app.command()
+    return cast(Callable[[CommandFunc], CommandFunc], decorator)
 
 
 def typer_auth_command(name: Optional[str] = None) -> Callable[[CommandFunc], CommandFunc]:
     """Typed wrapper around the auth subcommand decorator."""
     if name:
-        return cast(Callable[[CommandFunc], CommandFunc], auth_app.command(name))
-    return cast(Callable[[CommandFunc], CommandFunc], auth_app.command())
+        decorator: object = auth_app.command(name)
+    else:
+        decorator = auth_app.command()
+    return cast(Callable[[CommandFunc], CommandFunc], decorator)
 
 
 @typer_callback

--- a/src/main.py
+++ b/src/main.py
@@ -2,13 +2,29 @@
 
 from __future__ import annotations
 
-from typing import Callable, TypeVar, cast
+import logging
+import os
+from datetime import datetime
+from pathlib import Path
+from typing import Callable, List, NoReturn, Optional, TypeVar, cast
 
 import typer
 
-APP_HELP = "Backup and export Spotify playlists to JSON."
+from src.backup.exporter import CSVExporter
+from src.backup.service import BackupService, PlaylistBackupResult, PlaylistSyncResult
+from src.config import Settings, load_settings
+from src.config.settings import CONFIG_PATH_ENV
+from src.dropbox import auth as dropbox_auth
+from src.dropbox.client import DropboxClient
+from src.spotify import auth as spotify_auth
+from src.spotify.client import SpotifyClient
+from src.spotify.models import Playlist
 
-app = typer.Typer(help=APP_HELP)
+APP_HELP = "Backup and export Spotify playlists to CSV."
+
+app = typer.Typer(help=APP_HELP, no_args_is_help=True)
+auth_app = typer.Typer(help="Authentication helpers.")
+app.add_typer(auth_app, name="auth", help="Authenticate with Spotify and Dropbox.")
 
 CommandFunc = TypeVar("CommandFunc", bound=Callable[..., object])
 
@@ -18,21 +34,275 @@ def typer_callback(func: CommandFunc) -> CommandFunc:
     return cast(Callable[[CommandFunc], CommandFunc], app.callback())(func)
 
 
-def typer_command(func: CommandFunc) -> CommandFunc:
+def typer_command(name: Optional[str] = None) -> Callable[[CommandFunc], CommandFunc]:
     """Typed wrapper around the Typer command decorator."""
-    return cast(Callable[[CommandFunc], CommandFunc], app.command())(func)
+    if name:
+        return cast(Callable[[CommandFunc], CommandFunc], app.command(name))
+    return cast(Callable[[CommandFunc], CommandFunc], app.command())
+
+
+def typer_auth_command(name: Optional[str] = None) -> Callable[[CommandFunc], CommandFunc]:
+    """Typed wrapper around the auth subcommand decorator."""
+    if name:
+        return cast(Callable[[CommandFunc], CommandFunc], auth_app.command(name))
+    return cast(Callable[[CommandFunc], CommandFunc], auth_app.command())
 
 
 @typer_callback
-def cli() -> None:
-    """Backup and export Spotify playlists to JSON."""
-    return None
+def cli(
+    ctx: typer.Context,
+    config: Optional[Path] = typer.Option(
+        None,
+        "--config",
+        help="Path to a custom config file.",
+        dir_okay=False,
+        readable=True,
+    ),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable verbose output."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Show planned actions without changes."),
+) -> None:
+    """Backup and export Spotify playlists to CSV."""
+    ctx.ensure_object(dict)
+    ctx.obj["verbose"] = verbose
+    ctx.obj["dry_run"] = dry_run
+    if config:
+        if not config.exists():
+            raise typer.BadParameter(f"Config file not found: {config}")
+        os.environ[CONFIG_PATH_ENV] = str(config)
+        ctx.obj["config_path"] = config
+    _configure_logging(verbose)
 
 
-@typer_command
-def info() -> None:
-    """Display a placeholder message for the CLI."""
-    typer.echo("spotifyPlaylistBackups CLI is under construction.")
+def _configure_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=level, format="%(levelname)s: %(message)s")
+
+
+def _fail(message: str) -> NoReturn:
+    typer.secho(message, fg=typer.colors.RED)
+    raise typer.Exit(code=1)
+
+
+def _load_settings() -> Settings:
+    try:
+        return load_settings()
+    except Exception as exc:
+        _fail(f"Failed to load settings: {exc}")
+
+
+def _build_spotify_client(settings: Settings) -> SpotifyClient:
+    return SpotifyClient.from_settings(settings)
+
+
+def _build_dropbox_client(settings: Settings) -> DropboxClient:
+    return DropboxClient.from_settings(settings)
+
+
+class DryRunDropboxClient(DropboxClient):
+    """Dropbox client wrapper that skips write operations."""
+
+    def __init__(self, client: DropboxClient) -> None:
+        super().__init__(client._client, client._max_retries, client._backoff_factor)
+
+    def upload_file(self, content: str, path: str) -> None:
+        logging.info("Dry run: skipping upload to %s", path)
+
+    def ensure_folder_exists(self, path: str) -> None:
+        logging.info("Dry run: skipping folder creation for %s", path)
+
+
+def _build_backup_service(settings: Settings, dry_run: bool) -> BackupService:
+    spotify = _build_spotify_client(settings)
+    dropbox = _build_dropbox_client(settings)
+    if dry_run:
+        dropbox = DryRunDropboxClient(dropbox)
+    return BackupService(spotify, dropbox, CSVExporter(), settings)
+
+
+def _print_backup_result(result: PlaylistBackupResult) -> None:
+    if result.success:
+        typer.secho(
+            f"[OK] {result.playlist_name} ({result.track_count} tracks) -> {result.file_path}",
+            fg=typer.colors.GREEN,
+        )
+    else:
+        typer.secho(
+            f"[ERR] {result.playlist_name} - {result.error}",
+            fg=typer.colors.RED,
+        )
+
+
+def _print_sync_result(result: PlaylistSyncResult) -> None:
+    if result.updated:
+        typer.secho(
+            f"[OK] {result.playlist_name} (+{result.new_tracks} new, {result.total_tracks} total)",
+            fg=typer.colors.GREEN,
+        )
+    else:
+        typer.secho(
+            f"[OK] {result.playlist_name} (no changes, {result.total_tracks} total)",
+            fg=typer.colors.BLUE,
+        )
+
+
+def _select_playlist(playlists: List[Playlist], name_or_id: str) -> Playlist:
+    matches = [playlist for playlist in playlists if playlist.id == name_or_id or playlist.name == name_or_id]
+    if not matches:
+        _fail(f"No playlist found matching '{name_or_id}'.")
+    if len(matches) > 1:
+        names = ", ".join(playlist.id for playlist in matches)
+        _fail(f"Multiple playlists match '{name_or_id}'. IDs: {names}")
+    return matches[0]
+
+
+def _format_timestamp(value: datetime) -> str:
+    return value.astimezone().isoformat(timespec="seconds")
+
+
+@typer_auth_command()
+def spotify(ctx: typer.Context) -> None:
+    """Authenticate with Spotify."""
+    settings = _load_settings()
+    if ctx.obj.get("dry_run"):
+        typer.secho("Dry run: skipping Spotify auth flow.", fg=typer.colors.YELLOW)
+        return
+    try:
+        spotify_auth.get_spotify_client(settings)
+    except Exception as exc:
+        _fail(f"Spotify auth failed: {exc}")
+    typer.secho("Spotify authentication complete.", fg=typer.colors.GREEN)
+
+
+@typer_auth_command()
+def dropbox(ctx: typer.Context) -> None:
+    """Authenticate with Dropbox."""
+    settings = _load_settings()
+    if ctx.obj.get("dry_run"):
+        typer.secho("Dry run: skipping Dropbox auth flow.", fg=typer.colors.YELLOW)
+        return
+    try:
+        auth_url = dropbox_auth.start_auth_flow(settings)
+        typer.secho("Open this URL to authorize Dropbox:", fg=typer.colors.CYAN)
+        typer.echo(auth_url)
+        auth_code = typer.prompt("Paste the authorization code")
+        dropbox_auth.finish_auth_flow(auth_code, settings)
+    except Exception as exc:
+        _fail(f"Dropbox auth failed: {exc}")
+    typer.secho("Dropbox authentication complete.", fg=typer.colors.GREEN)
+
+
+@typer_auth_command("status")
+def auth_status() -> None:
+    """Show Spotify and Dropbox auth status."""
+    settings = _load_settings()
+    spotify_ok = spotify_auth.is_authenticated(settings)
+    dropbox_ok = dropbox_auth.is_authenticated(settings)
+    typer.secho(
+        f"Spotify: {'authenticated' if spotify_ok else 'missing token'}",
+        fg=typer.colors.GREEN if spotify_ok else typer.colors.RED,
+    )
+    typer.secho(
+        f"Dropbox: {'authenticated' if dropbox_ok else 'missing token'}",
+        fg=typer.colors.GREEN if dropbox_ok else typer.colors.RED,
+    )
+
+
+@typer_command()
+def backup(
+    ctx: typer.Context,
+    playlist: Optional[str] = typer.Option(None, "--playlist", help="Backup a specific playlist by name or id."),
+) -> None:
+    """Backup playlists to Dropbox."""
+    settings = _load_settings()
+    dry_run = bool(ctx.obj.get("dry_run"))
+    if dry_run:
+        typer.secho("Dry run: no Dropbox changes will be made.", fg=typer.colors.YELLOW)
+    service = _build_backup_service(settings, dry_run)
+
+    if playlist:
+        try:
+            playlists = service._spotify.get_all_playlists()
+            target = _select_playlist(playlists, playlist)
+            playlist_result = service._backup_playlist_data(target)
+        except Exception as exc:
+            _fail(f"Backup failed: {exc}")
+        _print_backup_result(playlist_result)
+        return
+
+    try:
+        backup_result = service.backup_all_playlists()
+    except Exception as exc:
+        _fail(f"Backup failed: {exc}")
+
+    typer.secho("Backing up playlists:", fg=typer.colors.CYAN)
+    for item in backup_result.playlist_results:
+        _print_backup_result(item)
+    typer.secho(
+        f"Backup complete: {backup_result.successful}/{backup_result.total_playlists} successful",
+        fg=typer.colors.GREEN if backup_result.failed == 0 else typer.colors.YELLOW,
+    )
+
+
+@typer_command("sync")
+def sync_playlists(ctx: typer.Context) -> None:
+    """Sync playlists, updating backups with new tracks only."""
+    settings = _load_settings()
+    dry_run = bool(ctx.obj.get("dry_run"))
+    if dry_run:
+        typer.secho("Dry run: no Dropbox changes will be made.", fg=typer.colors.YELLOW)
+    service = _build_backup_service(settings, dry_run)
+
+    try:
+        result = service.sync_all_playlists()
+    except Exception as exc:
+        _fail(f"Sync failed: {exc}")
+
+    typer.secho("Sync results:", fg=typer.colors.CYAN)
+    for item in result.results:
+        _print_sync_result(item)
+    typer.secho(
+        f"Sync complete: {result.playlists_updated}/{result.playlists_checked} updated, "
+        f"{result.total_new_tracks} new tracks",
+        fg=typer.colors.GREEN,
+    )
+
+
+@typer_command("list")
+def list_playlists(ctx: typer.Context) -> None:
+    """List Spotify playlists."""
+    settings = _load_settings()
+    verbose = bool(ctx.obj.get("verbose"))
+    spotify = _build_spotify_client(settings)
+    try:
+        playlists = spotify.get_all_playlists()
+    except Exception as exc:
+        _fail(f"Failed to list playlists: {exc}")
+    if not playlists:
+        typer.secho("No playlists found.", fg=typer.colors.YELLOW)
+        return
+    for playlist in playlists:
+        if verbose:
+            typer.echo(f"{playlist.name} ({playlist.total_tracks} tracks)")
+        else:
+            typer.echo(playlist.name)
+
+
+@typer_command()
+def status() -> None:
+    """Show backup status and last update time."""
+    settings = _load_settings()
+    dropbox = _build_dropbox_client(settings)
+    try:
+        files = dropbox.list_file_metadata(settings.backup_folder)
+    except Exception as exc:
+        _fail(f"Failed to load backup status: {exc}")
+    if not files:
+        typer.secho("No backups found in Dropbox.", fg=typer.colors.YELLOW)
+        return
+    latest = max(files, key=lambda item: item.server_modified)
+    typer.secho(f"Backups found: {len(files)}", fg=typer.colors.GREEN)
+    typer.secho(f"Latest backup: {latest.path}", fg=typer.colors.GREEN)
+    typer.echo(f"Last modified: {_format_timestamp(latest.server_modified)}")
 
 
 def main() -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,37 +1,579 @@
 """Tests for the CLI entry point."""
 
+from __future__ import annotations
+
+import os
 import sys
+from datetime import datetime, timezone
+from pathlib import Path
 
 import pytest
+import typer
 from typer.testing import CliRunner
 
-from src.main import APP_HELP, app, main
+from src.backup.service import BackupResult, PlaylistBackupResult, PlaylistSyncResult, SyncResult
+from src.config import Settings
+from src.config.settings import CONFIG_PATH_ENV
+from src.dropbox.client import DropboxClient, DropboxFileInfo
+from src.main import (
+    APP_HELP,
+    DryRunDropboxClient,
+    _build_backup_service,
+    _build_dropbox_client,
+    _build_spotify_client,
+    _print_backup_result,
+    _print_sync_result,
+    _select_playlist,
+    app,
+    main,
+)
+from src.spotify.models import Album, Artist, Playlist, Track
 
 
-class TestCli:
-    """Tests for the Typer CLI."""
-
-    def test_cli_help_includes_description(self) -> None:
-        """Ensure the CLI help text shows the app description."""
-        runner = CliRunner()
-        result = runner.invoke(app, ["--help"])
-        assert result.exit_code == 0
-        assert APP_HELP in result.output
-
-    def test_info_command_output(self) -> None:
-        """Ensure the info command outputs the placeholder message."""
-        runner = CliRunner()
-        result = runner.invoke(app, ["info"])
-        assert result.exit_code == 0
-        assert "under construction" in result.output
+def _settings() -> Settings:
+    return Settings.model_construct(
+        spotify_client_id="spotify-id",
+        spotify_client_secret="spotify-secret",
+        spotify_redirect_uri="http://localhost:8888/callback",
+        dropbox_app_key="dropbox-key",
+        dropbox_app_secret="dropbox-secret",
+        dropbox_refresh_token="refresh",
+        backup_folder="/backups",
+        csv_delimiter=",",
+        token_storage_path=".spotify_token.json",
+    )
 
 
-class TestMain:
-    """Tests for the module entry point."""
+def _track(track_id: str) -> Track:
+    return Track(
+        id=track_id,
+        name="Song",
+        artists=[Artist(id="artist-1", name="Artist")],
+        album=Album(id="album-1", name="Album", release_date="2024-01-01"),
+        duration_ms=1000,
+        added_at=datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc),
+        added_by="user-1",
+        is_local=False,
+    )
 
-    def test_main_runs_cli_help(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Ensure main() forwards to the CLI."""
-        monkeypatch.setattr(sys, "argv", ["main", "--help"])
-        with pytest.raises(SystemExit) as exc_info:
-            main()
-        assert exc_info.value.code == 0
+
+def _playlist(name: str, playlist_id: str, track_count: int = 1) -> Playlist:
+    tracks = [_track("track-1")]
+    return Playlist(
+        id=playlist_id,
+        name=name,
+        description=None,
+        owner="owner",
+        tracks=tracks,
+        snapshot_id="snap",
+        total_tracks=track_count,
+    )
+
+
+class FakeSpotifyClient:
+    def __init__(self, playlists: list[Playlist]) -> None:
+        self._playlists = playlists
+
+    def get_all_playlists(self) -> list[Playlist]:
+        return self._playlists
+
+
+class FakeBackupService:
+    def __init__(
+        self,
+        playlists: list[Playlist],
+        backup_result: BackupResult,
+        sync_result: SyncResult,
+        playlist_result: PlaylistBackupResult,
+    ) -> None:
+        self._spotify = FakeSpotifyClient(playlists)
+        self._backup_result = backup_result
+        self._sync_result = sync_result
+        self._playlist_result = playlist_result
+
+    def backup_all_playlists(self) -> BackupResult:
+        return self._backup_result
+
+    def sync_all_playlists(self) -> SyncResult:
+        return self._sync_result
+
+    def _backup_playlist_data(self, playlist: Playlist) -> PlaylistBackupResult:
+        return self._playlist_result
+
+
+class FakeDropboxClient:
+    def __init__(self, files: list[DropboxFileInfo]) -> None:
+        self._files = files
+
+    def list_file_metadata(self, _folder: str) -> list[DropboxFileInfo]:
+        return self._files
+
+
+class ErrorSpotifyClient:
+    def get_all_playlists(self) -> list[Playlist]:
+        raise RuntimeError("spotify error")
+
+
+class ErrorBackupService:
+    def __init__(self, playlists: list[Playlist]) -> None:
+        self._spotify = FakeSpotifyClient(playlists)
+
+    def backup_all_playlists(self) -> BackupResult:
+        raise RuntimeError("backup error")
+
+    def sync_all_playlists(self) -> SyncResult:
+        raise RuntimeError("sync error")
+
+    def _backup_playlist_data(self, playlist: Playlist) -> PlaylistBackupResult:
+        raise RuntimeError("backup error")
+
+
+def test_cli_help_includes_description() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert APP_HELP in result.output
+
+
+def test_cli_config_sets_env_and_handles_empty_list(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("backup:\n  folder: /backups\n")
+    monkeypatch.delenv(CONFIG_PATH_ENV, raising=False)
+    monkeypatch.setattr("src.main._load_settings", lambda: _settings())
+    monkeypatch.setattr("src.main._build_spotify_client", lambda _settings: FakeSpotifyClient([]))
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["--config", str(config_path), "list"])
+
+    assert result.exit_code == 0
+    assert "No playlists found." in result.output
+    assert os.environ[CONFIG_PATH_ENV] == str(config_path)
+
+
+def test_cli_config_missing_file_error() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["--config", "missing.yaml", "list"])
+
+    assert result.exit_code != 0
+    assert "Config file not found" in result.output
+
+
+def test_load_settings_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    def raise_error() -> Settings:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("src.main.load_settings", raise_error)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["list"])
+
+    assert result.exit_code == 1
+    assert "Failed to load settings" in result.output
+
+
+def test_auth_status_outputs_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("src.main._load_settings", lambda: _settings())
+    monkeypatch.setattr("src.main.spotify_auth.is_authenticated", lambda _settings: True)
+    monkeypatch.setattr("src.main.dropbox_auth.is_authenticated", lambda _settings: False)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["auth", "status"])
+
+    assert result.exit_code == 0
+    assert "Spotify: authenticated" in result.output
+    assert "Dropbox: missing token" in result.output
+
+
+def test_auth_spotify_dry_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("src.main._load_settings", lambda: _settings())
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["--dry-run", "auth", "spotify"])
+
+    assert result.exit_code == 0
+    assert "Dry run: skipping Spotify auth flow." in result.output
+
+
+def test_auth_spotify_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("src.main._load_settings", lambda: _settings())
+    monkeypatch.setattr("src.main.spotify_auth.get_spotify_client", lambda _settings: object())
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["auth", "spotify"])
+
+    assert result.exit_code == 0
+    assert "Spotify authentication complete." in result.output
+
+
+def test_auth_spotify_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail(_settings: Settings) -> None:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("src.main._load_settings", lambda: _settings())
+    monkeypatch.setattr("src.main.spotify_auth.get_spotify_client", fail)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["auth", "spotify"])
+
+    assert result.exit_code == 1
+    assert "Spotify auth failed" in result.output
+
+
+def test_auth_dropbox_dry_run(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("src.main._load_settings", lambda: _settings())
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["--dry-run", "auth", "dropbox"])
+
+    assert result.exit_code == 0
+    assert "Dry run: skipping Dropbox auth flow." in result.output
+
+
+def test_auth_dropbox_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("src.main._load_settings", lambda: _settings())
+    monkeypatch.setattr("src.main.dropbox_auth.start_auth_flow", lambda _settings: "http://example")
+    monkeypatch.setattr("src.main.dropbox_auth.finish_auth_flow", lambda _code, _settings: None)
+    monkeypatch.setattr("src.main.typer.prompt", lambda _prompt: "code")
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["auth", "dropbox"])
+
+    assert result.exit_code == 0
+    assert "Dropbox authentication complete." in result.output
+
+
+def test_auth_dropbox_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail(_settings: Settings) -> str:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("src.main._load_settings", lambda: _settings())
+    monkeypatch.setattr("src.main.dropbox_auth.start_auth_flow", fail)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["auth", "dropbox"])
+
+    assert result.exit_code == 1
+    assert "Dropbox auth failed" in result.output
+
+
+def test_list_playlists_verbose(monkeypatch: pytest.MonkeyPatch) -> None:
+    playlists = [_playlist("Favorites", "one", track_count=2)]
+    monkeypatch.setattr("src.main._load_settings", lambda: _settings())
+    monkeypatch.setattr("src.main._build_spotify_client", lambda _settings: FakeSpotifyClient(playlists))
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["--verbose", "list"])
+
+    assert result.exit_code == 0
+    assert "Favorites (2 tracks)" in result.output
+
+
+def test_list_playlists_non_verbose(monkeypatch: pytest.MonkeyPatch) -> None:
+    playlists = [_playlist("Favorites", "one", track_count=2)]
+    monkeypatch.setattr("src.main._load_settings", lambda: _settings())
+    monkeypatch.setattr("src.main._build_spotify_client", lambda _settings: FakeSpotifyClient(playlists))
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["list"])
+
+    assert result.exit_code == 0
+    assert "Favorites" in result.output
+
+
+def test_list_playlists_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("src.main._load_settings", lambda: _settings())
+    monkeypatch.setattr("src.main._build_spotify_client", lambda _settings: ErrorSpotifyClient())
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["list"])
+
+    assert result.exit_code == 1
+    assert "Failed to list playlists" in result.output
+
+
+def test_backup_all_playlists(monkeypatch: pytest.MonkeyPatch) -> None:
+    playlist_result = PlaylistBackupResult(
+        playlist_name="Favorites",
+        track_count=2,
+        file_path="/backups/Favorites.csv",
+        success=True,
+        error=None,
+    )
+    backup_result = BackupResult(
+        total_playlists=1,
+        successful=1,
+        failed=0,
+        playlist_results=[playlist_result],
+    )
+    sync_result = SyncResult(playlists_checked=0, playlists_updated=0, total_new_tracks=0, results=[])
+    service = FakeBackupService([_playlist("Favorites", "one")], backup_result, sync_result, playlist_result)
+
+    monkeypatch.setattr("src.main._load_settings", lambda: _settings())
+    monkeypatch.setattr("src.main._build_backup_service", lambda _settings, _dry_run: service)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["backup"])
+
+    assert result.exit_code == 0
+    assert "Backup complete: 1/1 successful" in result.output
+
+
+def test_backup_all_playlists_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    playlist = _playlist("Favorites", "one")
+    service = ErrorBackupService([playlist])
+
+    monkeypatch.setattr("src.main._load_settings", lambda: _settings())
+    monkeypatch.setattr("src.main._build_backup_service", lambda _settings, _dry_run: service)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["backup"])
+
+    assert result.exit_code == 1
+    assert "Backup failed" in result.output
+
+
+def test_backup_playlist_by_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    playlist_result = PlaylistBackupResult(
+        playlist_name="Focus",
+        track_count=1,
+        file_path="/backups/Focus.csv",
+        success=True,
+        error=None,
+    )
+    backup_result = BackupResult(
+        total_playlists=1,
+        successful=1,
+        failed=0,
+        playlist_results=[playlist_result],
+    )
+    sync_result = SyncResult(playlists_checked=0, playlists_updated=0, total_new_tracks=0, results=[])
+    playlist = _playlist("Focus", "focus-id")
+    service = FakeBackupService([playlist], backup_result, sync_result, playlist_result)
+
+    monkeypatch.setattr("src.main._load_settings", lambda: _settings())
+    monkeypatch.setattr("src.main._build_backup_service", lambda _settings, _dry_run: service)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["backup", "--playlist", "Focus"])
+
+    assert result.exit_code == 0
+    assert "Focus" in result.output
+
+
+def test_backup_playlist_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    playlist = _playlist("Focus", "focus-id")
+    service = ErrorBackupService([playlist])
+
+    monkeypatch.setattr("src.main._load_settings", lambda: _settings())
+    monkeypatch.setattr("src.main._build_backup_service", lambda _settings, _dry_run: service)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["backup", "--playlist", "Focus"])
+
+    assert result.exit_code == 1
+    assert "Backup failed" in result.output
+
+
+def test_backup_dry_run_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    playlist_result = PlaylistBackupResult(
+        playlist_name="Favorites",
+        track_count=1,
+        file_path="/backups/Favorites.csv",
+        success=True,
+        error=None,
+    )
+    backup_result = BackupResult(
+        total_playlists=1,
+        successful=1,
+        failed=0,
+        playlist_results=[playlist_result],
+    )
+    sync_result = SyncResult(playlists_checked=0, playlists_updated=0, total_new_tracks=0, results=[])
+    service = FakeBackupService([_playlist("Favorites", "one")], backup_result, sync_result, playlist_result)
+
+    monkeypatch.setattr("src.main._load_settings", lambda: _settings())
+    monkeypatch.setattr("src.main._build_backup_service", lambda _settings, _dry_run: service)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["--dry-run", "backup"])
+
+    assert result.exit_code == 0
+    assert "Dry run: no Dropbox changes will be made." in result.output
+
+
+def test_sync_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    playlist_result = PlaylistBackupResult(
+        playlist_name="Focus",
+        track_count=1,
+        file_path="/backups/Focus.csv",
+        success=True,
+        error=None,
+    )
+    backup_result = BackupResult(
+        total_playlists=0,
+        successful=0,
+        failed=0,
+        playlist_results=[],
+    )
+    sync_item = PlaylistSyncResult(
+        playlist_name="Focus",
+        new_tracks=1,
+        total_tracks=2,
+        updated=True,
+    )
+    sync_result = SyncResult(playlists_checked=1, playlists_updated=1, total_new_tracks=1, results=[sync_item])
+    service = FakeBackupService([_playlist("Focus", "focus-id")], backup_result, sync_result, playlist_result)
+
+    monkeypatch.setattr("src.main._load_settings", lambda: _settings())
+    monkeypatch.setattr("src.main._build_backup_service", lambda _settings, _dry_run: service)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["sync"])
+
+    assert result.exit_code == 0
+    assert "Sync complete: 1/1 updated, 1 new tracks" in result.output
+
+
+def test_sync_command_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    playlist = _playlist("Focus", "focus-id")
+    service = ErrorBackupService([playlist])
+
+    monkeypatch.setattr("src.main._load_settings", lambda: _settings())
+    monkeypatch.setattr("src.main._build_backup_service", lambda _settings, _dry_run: service)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["sync"])
+
+    assert result.exit_code == 1
+    assert "Sync failed" in result.output
+
+
+def test_sync_dry_run_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    playlist_result = PlaylistBackupResult(
+        playlist_name="Focus",
+        track_count=1,
+        file_path="/backups/Focus.csv",
+        success=True,
+        error=None,
+    )
+    backup_result = BackupResult(total_playlists=0, successful=0, failed=0, playlist_results=[])
+    sync_item = PlaylistSyncResult(
+        playlist_name="Focus",
+        new_tracks=0,
+        total_tracks=1,
+        updated=False,
+    )
+    sync_result = SyncResult(playlists_checked=1, playlists_updated=0, total_new_tracks=0, results=[sync_item])
+    service = FakeBackupService([_playlist("Focus", "focus-id")], backup_result, sync_result, playlist_result)
+
+    monkeypatch.setattr("src.main._load_settings", lambda: _settings())
+    monkeypatch.setattr("src.main._build_backup_service", lambda _settings, _dry_run: service)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["--dry-run", "sync"])
+
+    assert result.exit_code == 0
+    assert "Dry run: no Dropbox changes will be made." in result.output
+
+
+def test_status_command(monkeypatch: pytest.MonkeyPatch) -> None:
+    now = datetime(2024, 1, 2, 10, 0, tzinfo=timezone.utc)
+    files = [DropboxFileInfo(path="/backups/Focus.csv", server_modified=now)]
+    fake_dropbox = FakeDropboxClient(files)
+
+    monkeypatch.setattr("src.main._load_settings", lambda: _settings())
+    monkeypatch.setattr("src.main._build_dropbox_client", lambda _settings: fake_dropbox)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["status"])
+
+    assert result.exit_code == 0
+    assert "Backups found: 1" in result.output
+    assert "Latest backup: /backups/Focus.csv" in result.output
+
+
+def test_status_command_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_dropbox = FakeDropboxClient([])
+
+    monkeypatch.setattr("src.main._load_settings", lambda: _settings())
+    monkeypatch.setattr("src.main._build_dropbox_client", lambda _settings: fake_dropbox)
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["status"])
+
+    assert result.exit_code == 0
+    assert "No backups found in Dropbox." in result.output
+
+
+def test_status_command_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    class ErrorDropboxClient:
+        def list_file_metadata(self, _folder: str) -> list[DropboxFileInfo]:
+            raise RuntimeError("dropbox error")
+
+    monkeypatch.setattr("src.main._load_settings", lambda: _settings())
+    monkeypatch.setattr("src.main._build_dropbox_client", lambda _settings: ErrorDropboxClient())
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["status"])
+
+    assert result.exit_code == 1
+    assert "Failed to load backup status" in result.output
+
+
+def test_helpers_cover_select_and_prints() -> None:
+    _print_backup_result(
+        PlaylistBackupResult(
+            playlist_name="Broken",
+            track_count=0,
+            file_path="",
+            success=False,
+            error="boom",
+        )
+    )
+    _print_sync_result(
+        PlaylistSyncResult(
+            playlist_name="Focus",
+            new_tracks=0,
+            total_tracks=1,
+            updated=False,
+        )
+    )
+
+    with pytest.raises(typer.Exit):
+        _select_playlist([], "missing")
+    with pytest.raises(typer.Exit):
+        _select_playlist([_playlist("Dup", "one"), _playlist("Dup", "two")], "Dup")
+
+
+def test_build_client_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
+    spotify_client = object()
+    dropbox_client = object()
+
+    monkeypatch.setattr("src.main.SpotifyClient.from_settings", lambda _settings: spotify_client)
+    monkeypatch.setattr("src.main.DropboxClient.from_settings", lambda _settings: dropbox_client)
+
+    assert _build_spotify_client(_settings()) is spotify_client
+    assert _build_dropbox_client(_settings()) is dropbox_client
+
+
+def test_dry_run_dropbox_client_and_service(monkeypatch: pytest.MonkeyPatch) -> None:
+    base = DropboxClient(object())
+    dry_run = DryRunDropboxClient(base)
+    dry_run.upload_file("content", "/path")
+    dry_run.ensure_folder_exists("/path")
+
+    monkeypatch.setattr("src.main._build_spotify_client", lambda _settings: object())
+    monkeypatch.setattr("src.main._build_dropbox_client", lambda _settings: base)
+    service = _build_backup_service(_settings(), dry_run=True)
+
+    assert isinstance(service._dropbox, DryRunDropboxClient)
+
+
+def test_main_runs_cli_help(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(sys, "argv", ["main", "--help"])
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == 0

--- a/tests/test_spotify_auth.py
+++ b/tests/test_spotify_auth.py
@@ -62,15 +62,16 @@ class DummySpotify:
 
 
 def _settings() -> Settings:
-    return Settings.model_validate(
-        {
-            "SPOTIFY_CLIENT_ID": "client-id",
-            "SPOTIFY_CLIENT_SECRET": "client-secret",
-            "SPOTIFY_REDIRECT_URI": "http://localhost:8888/callback",
-            "DROPBOX_APP_KEY": "dropbox-key",
-            "DROPBOX_APP_SECRET": "dropbox-secret",
-            "TOKEN_STORAGE_PATH": ".spotify_token.json",
-        }
+    return Settings.model_construct(
+        spotify_client_id="client-id",
+        spotify_client_secret="client-secret",
+        spotify_redirect_uri="http://localhost:8888/callback",
+        dropbox_app_key="dropbox-key",
+        dropbox_app_secret="dropbox-secret",
+        dropbox_refresh_token=None,
+        backup_folder="/spotify-backups",
+        csv_delimiter=",",
+        token_storage_path=".spotify_token.json",
     )
 
 
@@ -173,14 +174,16 @@ def test_is_authenticated_handles_validation_error(monkeypatch: pytest.MonkeyPat
 
 
 def test_build_cache_handler_creates_parent(tmp_path: Path) -> None:
-    settings = Settings.model_validate(
-        {
-            "SPOTIFY_CLIENT_ID": "client-id",
-            "SPOTIFY_CLIENT_SECRET": "client-secret",
-            "DROPBOX_APP_KEY": "dropbox-key",
-            "DROPBOX_APP_SECRET": "dropbox-secret",
-            "TOKEN_STORAGE_PATH": str(tmp_path / "nested" / "token.json"),
-        }
+    settings = Settings.model_construct(
+        spotify_client_id="client-id",
+        spotify_client_secret="client-secret",
+        spotify_redirect_uri="http://localhost:8888/callback",
+        dropbox_app_key="dropbox-key",
+        dropbox_app_secret="dropbox-secret",
+        dropbox_refresh_token=None,
+        backup_folder="/spotify-backups",
+        csv_delimiter=",",
+        token_storage_path=str(tmp_path / "nested" / "token.json"),
     )
     cache_handler = auth_module._build_cache_handler(settings)
     assert (tmp_path / "nested").exists()


### PR DESCRIPTION
## Summary
- implement Typer CLI with auth, backup, sync, list, and status commands
- add dry-run and config handling plus colored output
- expand CLI and Dropbox client tests; document CLI workflow

## Testing
- venv/bin/pytest --cov=src --cov-report=term-missing
- venv/bin/pre-commit run --all-files