### PR TITLE
docs: expand README and user documentation (issue #17)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,62 +4,68 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Backup and export Spotify playlists to JSON
+Backup and sync Spotify playlists to CSV files stored in Dropbox.
 
-**Core workflow**: [Describe the main workflow of your application]
+**Core workflow**:
+1. Load settings from `config/config.yaml` (or env overrides).
+2. Authenticate with Spotify and Dropbox.
+3. Fetch playlists and tracks from Spotify.
+4. Export tracks to CSV (with BOM for Excel compatibility).
+5. Upload CSVs to Dropbox (backup) or append new tracks (sync).
 
 ## Constraints and Best Practices
 
-* This project is documentation-driven. Before starting work, read:
-  * README.md
-  * docs/INDEX.md
-* After finishing any task, update relevant documentation given changes in codebase.
-* Pre-commit checks must pass before committing. If pre-commit doesn't run, investigate and fix.
-** pyproject.toml, ci.yml and pre-commit-config.yaml have to have the same configuration so local pre-commit and CI checks behave in the same way.
-** Any code quality exceptions must be properly documented with a comment in code.
-* Branch naming: `feature/description`, `fix/description`, `docs/description`
-* Commit messages: Use conventional commits (feat:, fix:, docs:, refactor:, test:, chore:)
+- This project is documentation-driven. Before starting work, read:
+  - `README.md`
+  - `docs/INDEX.md`
+- After finishing any task, update relevant documentation given changes in codebase.
+- Pre-commit checks must pass before committing. If pre-commit doesn't run, investigate and fix.
+- `pyproject.toml`, `.github/workflows/ci.yml`, and `.pre-commit-config.yaml` should stay aligned.
+- Any code quality exceptions must be properly documented with a comment in code.
+- Branch naming: `feature/description`, `fix/description`, `docs/description`
+- Commit messages: Use conventional commits (feat:, fix:, docs:, refactor:, test:, chore:)
 
 ## Architecture
 
 ### Technology Stack
 - **Python**: 3.10+
-- [Add your main dependencies here]
+- **Typer**: CLI framework
+- **Spotipy**: Spotify API wrapper
+- **Dropbox SDK**: Dropbox API access
+- **Pydantic**: Settings validation
 
 ### Key Components
-1. **Component 1**:
-   - Description and purpose
-   - Key implementation details
-
-2. **Component 2**:
-   - Description and purpose
-   - Key implementation details
+1. **CLI (`src/main.py`)**:
+   - Parses global options and dispatches commands.
+   - Handles auth, backup, sync, list, and status.
+2. **Backup Service (`src/backup/service.py`)**:
+   - Orchestrates backups and syncs.
+   - Generates filenames and calls Dropbox client.
+3. **Export Helpers (`src/backup/exporter.py`)**:
+   - CSV formatting and BOM handling.
+4. **Spotify Client (`src/spotify/client.py`)**:
+   - Playlist/track retrieval with pagination and backoff.
+5. **Dropbox Client (`src/dropbox/client.py`)**:
+   - Upload, download, list metadata, and retries.
 
 ### Processing Strategy
-- [Describe your main processing approach]
-- Error handling and recovery
-- Logging and monitoring
+- Full backups export all tracks per playlist into CSV files.
+- Sync compares current Spotify tracks to existing CSV track IDs and appends new tracks only.
+- Logging is configured by the CLI (`--verbose`).
 
 ## Development Commands
 
 ### Initial Setup
 
 ```bash
-# Create virtual environment
 python3 -m venv venv
+source venv/bin/activate  # macOS/Linux
+# venv\Scripts\activate  # Windows
 
-# Activate virtual environment
-source venv/bin/activate  # On macOS/Linux
-# venv\Scripts\activate   # On Windows
-
-# Install dependencies
 pip install -r requirements.txt
 pip install -r requirements-dev.txt
-
-# Install pre-commit hooks
 pre-commit install
 
-# Copy and configure settings
 cp config/config.example.yaml config/config.yaml
 # Edit config/config.yaml with your settings
 ```
@@ -67,47 +73,23 @@ cp config/config.example.yaml config/config.yaml
 ### Running Tests
 
 ```bash
-# Activate virtual environment (if not already active)
-source venv/bin/activate
-
-# Run all tests
 pytest
-
-# Run tests with coverage
 pytest --cov=src --cov-report=term-missing
-
-# Run specific test file
 pytest tests/test_main.py
 ```
 
-### Common Commands
+### Code Quality
 
 ```bash
-# Activate virtual environment
-source venv/bin/activate
-
-# Update dependencies
-pip install --upgrade -r requirements.txt
-
-# Run linting
-black src/
-isort src/
-flake8 src/
-mypy src/
-
-# Run security checks
-bandit -r src/ -ll
-
-# Deactivate virtual environment when done
-deactivate
+pre-commit run --all-files
 ```
 
 ### Running the Application
 
 ```bash
-# Activate virtual environment
-source venv/bin/activate
-
-# Run main application
-python -m src.main
+python -m src.main --help
+python -m src.main auth spotify
+python -m src.main auth dropbox
+python -m src.main backup
+python -m src.main sync
 ```

--- a/README.md
+++ b/README.md
@@ -4,18 +4,17 @@
 ![Python](https://img.shields.io/badge/python-3.10+-blue.svg)
 ![Coverage](https://img.shields.io/badge/coverage-95%25-green.svg)
 
-Backup and export Spotify playlists to JSON
+Backup and sync Spotify playlists to CSV files in Dropbox.
 
 ## Features
 
-- Typer-based CLI scaffold
-- YAML configuration template for Spotify and Dropbox credentials
-- Spotify OAuth client wrapper and playlist data models
-- Dropbox OAuth helper for token persistence
-- Dropbox client wrapper for file operations
-- Backup service orchestrator for full playlist exports
-- CSV export utilities for playlist backups
-- Test and quality tooling wired into CI
+- Typer-based CLI with auth, backup, sync, list, and status commands
+- YAML configuration with environment variable overrides
+- Spotify and Dropbox OAuth helpers
+- CSV exports with Excel-friendly BOM and safe filenames
+- Sync workflow that appends only new tracks
+- Dry-run support for planning changes without writes
+- Strong test coverage and pre-commit enforcement
 
 ## Quick Start
 
@@ -32,7 +31,7 @@ git clone https://github.com/amendez13/spotifyPlaylistBackups.git
 cd spotifyPlaylistBackups
 ```
 
-2. Create and activate virtual environment:
+2. Create and activate a virtual environment:
 ```bash
 python3 -m venv venv
 source venv/bin/activate  # On macOS/Linux
@@ -50,60 +49,70 @@ cp config/config.example.yaml config/config.yaml
 # Edit config/config.yaml with your settings
 ```
 
-### Usage
-
+5. Authenticate and run a backup:
 ```bash
-# Run the application
-python -m src.main --help
-
-# Placeholder command
-python -m src.main info
+python -m src.main auth spotify
+python -m src.main auth dropbox
+python -m src.main backup
 ```
 
-On first Spotify-enabled command run, the app will open a browser for OAuth consent and cache tokens in `.spotify_token.json`.
+## Usage
+
+```bash
+# Show available commands
+python -m src.main --help
+
+# Backup all playlists
+python -m src.main backup
+
+# Backup a single playlist by name or id
+python -m src.main backup --playlist "Chill Vibes"
+
+# Sync playlists (only new tracks)
+python -m src.main sync
+
+# List playlists (add -v for counts)
+python -m src.main list -v
+
+# Show backup status
+python -m src.main status
+```
+
+### Output Example
+
+```text
+Backing up playlists:
+[OK] Chill Vibes (45 tracks) -> /spotify-backups/Chill Vibes-abc123.csv
+[OK] Workout Mix (78 tracks) -> /spotify-backups/Workout Mix-def456.csv
+Backup complete: 2/2 successful
+```
 
 ## Configuration
 
-Configuration is stored in `config/config.yaml`. See `config/config.example.yaml` for all available options.
+Configuration lives in `config/config.yaml` and can be overridden with env vars.
+See `config/config.example.yaml` for the full schema and `docs/SETUP.md` for setup details.
 
-```yaml
-# Example configuration
-app:
-  debug: false
-  log_level: INFO
+## Documentation
 
-spotify:
-  client_id: REPLACE_WITH_SPOTIFY_CLIENT_ID
-  client_secret: REPLACE_WITH_SPOTIFY_CLIENT_SECRET
-  redirect_uri: http://localhost:8888/callback
-
-dropbox:
-  app_key: REPLACE_WITH_DROPBOX_APP_KEY
-  app_secret: REPLACE_WITH_DROPBOX_APP_SECRET
-  # refresh_token: REPLACE_WITH_DROPBOX_REFRESH_TOKEN
-
-backup:
-  folder: /spotify-backups
-  csv_delimiter: ","
-
-tokens:
-  storage_path: .spotify_token.json
-```
+- [Documentation Index](docs/INDEX.md)
+- [Setup Guide](docs/SETUP.md)
+- [Usage Guide](docs/USAGE.md)
+- [Architecture](docs/ARCHITECTURE.md)
 
 ## Project Structure
 
 ```
 spotifyPlaylistBackups/
 ├── .github/workflows/    # CI/CD configuration
-├── .claude/              # Claude Code configuration
 ├── config/               # Configuration files
 ├── docs/                 # Documentation
+├── scripts/              # Helper scripts
 ├── src/                  # Source code
-│   ├── backup/           # Backup logic (placeholder)
-│   ├── config/           # Settings and config helpers (placeholder)
-│   ├── dropbox/          # Dropbox integration (placeholder)
-│   └── spotify/          # Spotify integration (placeholder)
-├── tests/                # Test files
+│   ├── backup/           # Backup and sync services
+│   ├── config/           # Settings loading
+│   ├── dropbox/          # Dropbox auth and client
+│   └── spotify/          # Spotify auth, client, and models
+├── tests/                # Test suite
 ├── CLAUDE.md             # AI assistant guidance
 ├── README.md             # This file
 ├── pyproject.toml        # Tool configuration
@@ -112,70 +121,20 @@ spotifyPlaylistBackups/
 
 ## Development
 
-### Setup Development Environment
-
 ```bash
 # Install dev dependencies
 pip install -r requirements-dev.txt
 
 # Install pre-commit hooks
 pre-commit install
-```
 
-### Running Tests
-
-```bash
-# Run all tests
+# Run tests
 pytest
 
-# Run with coverage
-pytest --cov=src --cov-report=term-missing
+# Run pre-commit checks
+pre-commit run --all-files
 ```
-
-### Code Quality
-
-This project uses:
-- **Black** for code formatting
-- **isort** for import sorting
-- **flake8** for linting
-- **mypy** for type checking
-- **bandit** for security scanning
-- **pip-audit** for dependency vulnerability checking
-
-All checks run automatically via pre-commit hooks and CI.
-
-## CI/CD
-
-GitHub Actions runs the following checks on every push and PR:
-
-1. **Lint**: Black, isort, flake8, mypy
-2. **Test**: pytest across Python 3.10, 3.11, 3.12
-3. **Coverage**: 95% minimum coverage
-4. **Security**: bandit and pip-audit
-
-See [docs/CI.md](docs/CI.md) for details.
-
-## Documentation
-
-- [Documentation Index](docs/INDEX.md) - All documentation
-- [Setup Guide](docs/SETUP.md) - Installation and configuration
-- [CI Documentation](docs/CI.md) - CI/CD pipeline details
-
-## Contributing
-
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Make your changes
-4. Run tests and linting
-5. Commit your changes (`git commit -m 'feat: add amazing feature'`)
-6. Push to the branch (`git push origin feature/amazing-feature`)
-7. Open a Pull Request
 
 ## License
 
-[Choose your license]
-
-## Acknowledgments
-
-- [Acknowledgment 1]
-- [Acknowledgment 2]
+License not specified yet.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,6 +6,22 @@ This document describes the technical architecture of spotifyPlaylistBackups.
 
 spotifyPlaylistBackups fetches Spotify playlists, converts them to CSV, and uploads the results to Dropbox. The system is split into configuration management, API clients, and a backup orchestration layer.
 
+## Project Structure
+
+```
+spotifyPlaylistBackups/
+├── config/               # YAML configuration templates
+├── docs/                 # User and developer documentation
+├── scripts/              # Helper scripts (authorization utilities)
+├── src/
+│   ├── backup/           # Backup/export/sync orchestration
+│   ├── config/           # Settings loading and validation
+│   ├── dropbox/          # Dropbox auth and client
+│   ├── spotify/          # Spotify auth, client, and models
+│   └── main.py           # Typer CLI entry point
+└── tests/                # Unit tests
+```
+
 ## System Components
 
 ### Component Diagram
@@ -58,6 +74,18 @@ spotifyPlaylistBackups fetches Spotify playlists, converts them to CSV, and uplo
 **Responsibilities**:
 - OAuth token handling (`src/dropbox/auth.py`)
 - File upload and folder management (`src/dropbox/client.py`)
+
+### API Integration Details
+
+**Spotify**:
+- Uses Spotipy to access playlist and track APIs.
+- Handles pagination and rate limiting in `SpotifyClient`.
+- Uses cached OAuth tokens stored at `TOKEN_STORAGE_PATH`.
+
+**Dropbox**:
+- Uses the Dropbox SDK with refresh tokens.
+- Uploads full CSVs and downloads existing backups for sync.
+- Lists backup metadata for status reporting.
 
 ### Backup Service
 
@@ -132,10 +160,10 @@ print(sync_result.playlists_updated, sync_result.total_new_tracks)
 ### CLI Example
 
 ```bash
-spotify-backup auth spotify
-spotify-backup auth dropbox
-spotify-backup backup
-spotify-backup sync
+python -m src.main auth spotify
+python -m src.main auth dropbox
+python -m src.main backup
+python -m src.main sync
 ```
 
 ## Design Decisions

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,151 +1,52 @@
 # Documentation Index
 
-Welcome to the spotifyPlaylistBackups documentation. This index provides easy access to all documentation in this repository.
+Welcome to the spotifyPlaylistBackups documentation.
 
 ## Quick Links
 
-**For Users:**
-- [Getting Started](#getting-started) - Start here if you're new
-- [Setup Guide](#setup-guides) - Configure your environment
-- [Configuration](#configuration) - Settings and overrides
-- [Dropbox Authentication](#dropbox-authentication) - OAuth flow and token storage
-- [Dropbox Client](#dropbox-client) - File operations and retries
-- [CSV Export](#csv-export) - Export playlists to CSV
-- [Spotify Authentication](#spotify-authentication) - OAuth flow and token caching
-- [Spotify Client](#spotify-client) - Fetch playlists and tracks
+**For Users**
+- [README](../README.md) - Overview and quick start
+- [Setup Guide](SETUP.md) - Create API apps and configure credentials
+- [Usage Guide](USAGE.md) - Command reference and workflows
+- [Configuration](CONFIG.md) - YAML and env var reference
 
-**For Developers:**
-- [Architecture](#architecture) - Technical design and implementation details
-- [Developer Guide](#developer-resources) - Contributing and development workflow
+**For Developers**
+- [Architecture](ARCHITECTURE.md) - System design and data flow
+- [CI](CI.md) - CI pipeline and local checks
+- [CLAUDE.md](../CLAUDE.md) - Project guidance for AI assistants
 
 ---
 
 ## Getting Started
 
-**[README.md](../README.md)**
-- Project overview and features
-- Quick start guide
-- Installation instructions
-- Basic configuration
-- Usage examples
-- Troubleshooting common issues
-
----
-
-## Setup Guides
-
-**[SETUP.md](SETUP.md)**
-- Prerequisites and system requirements
-- Step-by-step installation guide
-- Configuration options
-- Verification steps
-- Troubleshooting
+- **[README.md](../README.md)**: Overview, installation, and quick start.
+- **[SETUP.md](SETUP.md)**: Step-by-step setup with Spotify/Dropbox app creation.
+- **[USAGE.md](USAGE.md)**: Commands, workflows, automation, troubleshooting.
 
 ## Configuration
 
-**[CONFIG.md](CONFIG.md)**
-- YAML schema and env overrides
-- Required fields and validation
-- Usage example
+- **[CONFIG.md](CONFIG.md)**: YAML schema and environment variable overrides.
 
-## Dropbox Authentication
+## Authentication
 
-**[DROPBOX_AUTH.md](DROPBOX_AUTH.md)**
-- OAuth flow and scopes
-- Token persistence
-- Usage examples
+- **[SPOTIFY_AUTH.md](SPOTIFY_AUTH.md)**: Spotify OAuth flow and token caching.
+- **[DROPBOX_AUTH.md](DROPBOX_AUTH.md)**: Dropbox OAuth flow and refresh tokens.
 
-## Dropbox Client
+## Integration Details
 
-**[DROPBOX_CLIENT.md](DROPBOX_CLIENT.md)**
-- File operations and retry behavior
-- Path handling
-- Usage examples
-
-## CSV Export
-
-**[EXPORT.md](EXPORT.md)**
-- CSV schema and encoding
-- Filename generation
-- Usage example
-
-## Spotify Authentication
-
-**[SPOTIFY_AUTH.md](SPOTIFY_AUTH.md)**
-- OAuth flow and scopes
-- Token caching behavior
-- Usage examples
-
-## Spotify Client
-
-**[SPOTIFY_CLIENT.md](SPOTIFY_CLIENT.md)**
-- Data models for playlists and tracks
-- Pagination and rate-limit handling
-- Usage examples
-
----
+- **[SPOTIFY_CLIENT.md](SPOTIFY_CLIENT.md)**: Playlist/track retrieval and pagination.
+- **[DROPBOX_CLIENT.md](DROPBOX_CLIENT.md)**: File operations and retry logic.
+- **[EXPORT.md](EXPORT.md)**: CSV schema and export behavior.
 
 ## Architecture
 
-**[ARCHITECTURE.md](ARCHITECTURE.md)**
-- System architecture overview
-- Component design
-- Design decisions and trade-offs
-- Performance considerations
-- Security implications
-
----
+- **[ARCHITECTURE.md](ARCHITECTURE.md)**: Component overview, data flow, and design decisions.
 
 ## Developer Resources
 
-**[CLAUDE.md](../CLAUDE.md)**
-- Project overview for AI assistants
-- Technology stack details
-- Core workflow and key components
-- Development commands and setup
-- Common development tasks
+- **[CI.md](CI.md)**: CI workflows and local equivalents.
+- **[CLAUDE.md](../CLAUDE.md)**: Development guidance and key commands.
 
-**[CI.md](CI.md)**
-- Continuous Integration (CI) pipeline documentation
-- GitHub Actions workflow details
-- Code quality and testing automation
-- Local development workflow
-- Running CI checks locally
-- Troubleshooting CI failures
+## Planning
 
----
-
-## Project Status
-
-**Current Phase:** [Current development phase]
-- [Feature 1]
-- [Feature 2]
-
-**Next Phase:** [Upcoming phase]
-- [Planned feature 1]
-- [Planned feature 2]
-
-**Future:** [Long-term plans]
-- [Future feature 1]
-- [Future feature 2]
-
----
-
-## Quick Reference
-
-| Document | Purpose | Audience |
-|----------|---------|----------|
-| [README.md](../README.md) | Getting started, installation, usage | All users |
-| [SETUP.md](SETUP.md) | Environment configuration | All users |
-| [ARCHITECTURE.md](ARCHITECTURE.md) | Technical architecture and design | Developers |
-| [CI.md](CI.md) | CI/CD pipeline and development workflow | Developers |
-| [CLAUDE.md](../CLAUDE.md) | AI assistant guidance | Claude Code |
-
----
-
-## Task Management
-
-**[planning/TASK_MANAGEMENT.md](planning/TASK_MANAGEMENT.md)**
-- Development phases and milestones
-- Task tracking and prioritization
-- Progress monitoring
+- **[planning/TASK_MANAGEMENT.md](planning/TASK_MANAGEMENT.md)**: Milestones and task tracking.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -1,16 +1,12 @@
 # Setup Guide
 
-This guide walks you through setting up spotifyPlaylistBackups for development or usage.
+This guide walks you through setting up spotifyPlaylistBackups for local usage or development.
 
 ## Prerequisites
 
 - Python 3.10 or higher
 - pip (Python package installer)
 - git
-
-### Optional
-
-- [List optional dependencies]
 
 ## Installation
 
@@ -24,7 +20,6 @@ cd spotifyPlaylistBackups
 ### 2. Create Virtual Environment
 
 ```bash
-# Create virtual environment
 python3 -m venv venv
 
 # Activate virtual environment
@@ -42,33 +37,39 @@ pip install -r requirements.txt
 pip install -r requirements-dev.txt
 ```
 
-### 4. Configure the Application
+## Create Spotify API App
+
+1. Visit the Spotify Developer Dashboard: https://developer.spotify.com/dashboard
+2. Create a new app and give it a name/description.
+3. Open the app settings and add a redirect URI:
+   - `http://localhost:8888/callback`
+4. Copy the Client ID and Client Secret for `config/config.yaml`.
+
+![Spotify Developer Dashboard](images/spotify-app-create.svg)
+![Spotify App Settings](images/spotify-app-settings.svg)
+
+## Create Dropbox API App
+
+1. Visit the Dropbox App Console: https://www.dropbox.com/developers/apps
+2. Create a new app with Scoped access.
+3. Choose **App folder** access to keep backups in `/Apps/<app-name>`.
+4. In **Permissions**, enable:
+   - `files.content.read`
+   - `files.content.write`
+5. Copy the App Key and App Secret for `config/config.yaml`.
+
+![Dropbox App Console](images/dropbox-app-create.svg)
+![Dropbox App Settings](images/dropbox-app-settings.svg)
+
+## Configure the Application
+
+### 1. Create the Config File
 
 ```bash
-# Copy example configuration
 cp config/config.example.yaml config/config.yaml
-
-# Edit configuration with your settings
-# On macOS/Linux:
-nano config/config.yaml
-# Or use your preferred editor
 ```
 
-### 5. Verify Installation
-
-```bash
-# Run tests to verify setup
-pytest
-
-# Or run the application
-python -m src.main --help
-```
-
-## Configuration
-
-### config/config.yaml
-
-The main configuration file. See `config/config.example.yaml` for all available options.
+### 2. Update Config Values
 
 ```yaml
 spotify:
@@ -89,9 +90,19 @@ tokens:
   storage_path: .spotify_token.json
 ```
 
-### Environment Variables
+### 3. Authenticate
 
-You can also configure the application using environment variables:
+```bash
+# Spotify OAuth
+python -m src.main auth spotify
+
+# Dropbox OAuth (stores refresh token in config/config.yaml)
+python -m src.main auth dropbox
+```
+
+## Environment Variables
+
+You can override the YAML config with environment variables:
 
 | Variable | Description | Default |
 |----------|-------------|---------|
@@ -106,65 +117,19 @@ You can also configure the application using environment variables:
 | `TOKEN_STORAGE_PATH` | Token cache path | `.spotify_token.json` |
 | `SPOTIFY_BACKUPS_CONFIG_PATH` | Path to config YAML | `config/config.yaml` |
 
-### Spotify Authentication
-
-On first use, the CLI will open a browser window for Spotify OAuth consent. After approving access, paste the redirect URL back into the prompt. Tokens are cached locally at `.spotify_token.json` (or the path in `TOKEN_STORAGE_PATH`).
-
-### Dropbox Authentication
-
-Run the Dropbox authorization helper to obtain a refresh token and store it in `config/config.yaml`:
+## Verify Installation
 
 ```bash
-python scripts/authorize_dropbox.py
+python -m src.main --help
+python -m src.main list
 ```
 
-See [DROPBOX_AUTH.md](DROPBOX_AUTH.md) for details.
+## Notes
 
-## Development Setup
-
-### Install Pre-commit Hooks
-
-```bash
-# Install pre-commit hooks
-pre-commit install
-
-# Verify hooks work
-pre-commit run --all-files
-```
-
-### IDE Setup
-
-#### VS Code
-
-Recommended extensions:
-- Python
-- Pylance
-- Black Formatter
-- isort
-
-Settings (`.vscode/settings.json`):
-```json
-{
-    "python.defaultInterpreterPath": "./venv/bin/python",
-    "python.formatting.provider": "black",
-    "editor.formatOnSave": true,
-    "[python]": {
-        "editor.codeActionsOnSave": {
-            "source.organizeImports": true
-        }
-    }
-}
-```
-
-#### PyCharm
-
-1. Set Python interpreter to `./venv/bin/python`
-2. Enable Black formatter
-3. Enable isort for imports
+- The images in this guide are placeholders to indicate where screenshots belong.
+- See `docs/CONFIG.md` for a full configuration reference.
 
 ## Troubleshooting
-
-### Common Issues
 
 **Virtual environment not activated**
 ```bash
@@ -176,17 +141,17 @@ source venv/bin/activate
 pip install -r requirements.txt
 ```
 
-**Pre-commit hooks not running**
-```bash
-pre-commit install
-```
-
 **Configuration file not found**
 ```bash
 cp config/config.example.yaml config/config.yaml
 ```
 
-### Getting Help
+**Dropbox refresh token missing**
+```bash
+python -m src.main auth dropbox
+```
+
+## Getting Help
 
 - Check the [Documentation Index](INDEX.md)
 - Review [CI documentation](CI.md) for testing issues

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,0 +1,150 @@
+# Usage Guide
+
+This guide covers CLI commands, common workflows, automation, and troubleshooting.
+
+## Command Reference
+
+All commands are available via:
+
+```bash
+python -m src.main --help
+```
+
+### Global Options
+
+| Option | Description |
+|--------|-------------|
+| `--config PATH` | Use a custom config file path |
+| `--verbose`, `-v` | Enable verbose logging |
+| `--dry-run` | Show actions without writing to Dropbox |
+
+### Auth Commands
+
+```bash
+python -m src.main auth spotify
+python -m src.main auth dropbox
+python -m src.main auth status
+```
+
+- `auth spotify` opens the browser and stores tokens in `.spotify_token.json`.
+- `auth dropbox` walks through OAuth and stores the refresh token in `config/config.yaml`.
+- `auth status` shows token availability.
+
+### Backup Commands
+
+```bash
+python -m src.main backup
+python -m src.main backup --playlist "Chill Vibes"
+```
+
+- `backup` exports all playlists to CSV and uploads to Dropbox.
+- `backup --playlist` targets a single playlist by name or id.
+
+### Sync Commands
+
+```bash
+python -m src.main sync
+```
+
+- `sync` downloads existing CSVs, detects new tracks, and appends only new rows.
+
+### Info Commands
+
+```bash
+python -m src.main list
+python -m src.main list -v
+python -m src.main status
+```
+
+- `list` shows playlists; `-v` adds track counts.
+- `status` reports the latest Dropbox backup timestamp.
+
+## Common Workflows
+
+### First-Time Setup
+
+```bash
+python -m src.main auth spotify
+python -m src.main auth dropbox
+python -m src.main backup
+```
+
+### Weekly Sync
+
+```bash
+python -m src.main sync
+```
+
+### Safe Preview (Dry Run)
+
+```bash
+python -m src.main --dry-run backup
+python -m src.main --dry-run sync
+```
+
+## Automation
+
+### Linux/macOS (cron)
+
+```cron
+# Sync every Sunday at 02:30
+30 2 * * 0 /path/to/repo/venv/bin/python -m src.main sync --config /path/to/config.yaml
+```
+
+### macOS (launchd)
+
+Create `~/Library/LaunchAgents/com.spotify.backup.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>Label</key>
+    <string>com.spotify.backup</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>/path/to/repo/venv/bin/python</string>
+      <string>-m</string>
+      <string>src.main</string>
+      <string>sync</string>
+    </array>
+    <key>StartCalendarInterval</key>
+    <dict>
+      <key>Weekday</key>
+      <integer>1</integer>
+      <key>Hour</key>
+      <integer>2</integer>
+      <key>Minute</key>
+      <integer>30</integer>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>/tmp/spotify-backup.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/spotify-backup.err</string>
+  </dict>
+</plist>
+```
+
+Load it:
+
+```bash
+launchctl load ~/Library/LaunchAgents/com.spotify.backup.plist
+```
+
+## Troubleshooting
+
+**Spotify auth fails or redirect URI mismatch**
+- Confirm the redirect URI matches `http://localhost:8888/callback` in the Spotify dashboard and config.
+
+**Dropbox auth fails or token missing**
+- Re-run `python -m src.main auth dropbox` and ensure the refresh token is saved.
+
+**Rate limit errors**
+- Re-run later; the Spotify/Dropbox clients retry automatically with backoff.
+
+**Config file errors**
+- Validate `config/config.yaml` matches `config/config.example.yaml`.
+
+**Unexpected playlist duplicates**
+- Use playlist IDs when `backup --playlist` reports multiple matches.

--- a/docs/images/dropbox-app-create.svg
+++ b/docs/images/dropbox-app-create.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="240" viewBox="0 0 800 240">
+  <rect width="800" height="240" fill="#f5f5f5" />
+  <rect x="20" y="20" width="760" height="200" fill="#ffffff" stroke="#d0d0d0" />
+  <text x="40" y="70" font-family="Arial, sans-serif" font-size="20" fill="#333333">Dropbox App Console</text>
+  <text x="40" y="110" font-family="Arial, sans-serif" font-size="16" fill="#555555">Placeholder screenshot: Create app and permissions</text>
+  <text x="40" y="150" font-family="Arial, sans-serif" font-size="14" fill="#777777">Replace with an actual screenshot in production docs.</text>
+</svg>

--- a/docs/images/dropbox-app-settings.svg
+++ b/docs/images/dropbox-app-settings.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="240" viewBox="0 0 800 240">
+  <rect width="800" height="240" fill="#f5f5f5" />
+  <rect x="20" y="20" width="760" height="200" fill="#ffffff" stroke="#d0d0d0" />
+  <text x="40" y="70" font-family="Arial, sans-serif" font-size="20" fill="#333333">Dropbox App Settings</text>
+  <text x="40" y="110" font-family="Arial, sans-serif" font-size="16" fill="#555555">Placeholder screenshot: App key/secret and redirect URL</text>
+  <text x="40" y="150" font-family="Arial, sans-serif" font-size="14" fill="#777777">Replace with an actual screenshot in production docs.</text>
+</svg>

--- a/docs/images/spotify-app-create.svg
+++ b/docs/images/spotify-app-create.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="240" viewBox="0 0 800 240">
+  <rect width="800" height="240" fill="#f5f5f5" />
+  <rect x="20" y="20" width="760" height="200" fill="#ffffff" stroke="#d0d0d0" />
+  <text x="40" y="70" font-family="Arial, sans-serif" font-size="20" fill="#333333">Spotify Developer Dashboard</text>
+  <text x="40" y="110" font-family="Arial, sans-serif" font-size="16" fill="#555555">Placeholder screenshot: Create App flow</text>
+  <text x="40" y="150" font-family="Arial, sans-serif" font-size="14" fill="#777777">Replace with an actual screenshot in production docs.</text>
+</svg>

--- a/docs/images/spotify-app-settings.svg
+++ b/docs/images/spotify-app-settings.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="240" viewBox="0 0 800 240">
+  <rect width="800" height="240" fill="#f5f5f5" />
+  <rect x="20" y="20" width="760" height="200" fill="#ffffff" stroke="#d0d0d0" />
+  <text x="40" y="70" font-family="Arial, sans-serif" font-size="20" fill="#333333">Spotify App Settings</text>
+  <text x="40" y="110" font-family="Arial, sans-serif" font-size="16" fill="#555555">Placeholder screenshot: Client ID, Secret, Redirect URI</text>
+  <text x="40" y="150" font-family="Arial, sans-serif" font-size="14" fill="#777777">Replace with an actual screenshot in production docs.</text>
+</svg>


### PR DESCRIPTION
## Summary
- overhaul README and documentation index for current CLI
- add setup, usage, and architecture details with placeholder screenshots
- refresh CLAUDE.md with actual workflow and dev commands

## Testing
- venv/bin/pytest
- venv/bin/pre-commit run --all-files